### PR TITLE
build: upgrade Go to 1.17

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Update dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
 module github.com/edgelaboratories/daycount
 
-go 1.13
+go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
- Upgrade `go.mod` to 1.17 with `go mod tidy -go=1.17` (compatible with Go 1.16)
- Upgrade Github action's Go version
- Test only for Go 1.17 on