### PR TITLE
feat: deprecate YearFractionDiff

### DIFF
--- a/daycount.go
+++ b/daycount.go
@@ -51,13 +51,6 @@ func YearFraction(from, to date.Date, convention Convention) float64 {
 	return NewDayCounter(convention)(from, to)
 }
 
-// YearFractionDiff is the same as YearFraction.
-//
-// Deprecated: YearFractionDiff is an alias for YearFraction.
-func YearFractionDiff(from, to date.Date, convention Convention) float64 {
-	return YearFraction(from, to, convention)
-}
-
 const (
 	threeSixtyDays     = 360.0
 	threeSixtyFiveDays = 365.0

--- a/daycount_test.go
+++ b/daycount_test.go
@@ -70,8 +70,6 @@ func Test_YearFraction(t *testing.T) {
 			t.Parallel()
 
 			assert.InEpsilon(t, tc.expected, YearFraction(from, to, tc.convention), epsilon)
-			// This check can be removed once YearFractionDiff has been deprecated.
-			assert.InEpsilon(t, tc.expected, YearFractionDiff(from, to, tc.convention), epsilon)
 		})
 	}
 }


### PR DESCRIPTION
Deprecate `YearFractionDiff` as anticipated in 0ecdd27.
**WARN**: this is a breaking change.
Users are requested to switch to `YearFraction` instead.