### PR TITLE
code: update convention syntax

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Update dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/convention.go
+++ b/convention.go
@@ -1,7 +1,6 @@
 package daycount
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -44,10 +43,18 @@ const (
 	// If the first date is the last day of February, then it is changed to the 1st of March.
 	// If the second date is the last day of February, then it is changed to the 1st of March.
 	ThirtyThreeSixtyGerman
+
+	// outOfRangeConvention is a sentinel value that allows to bound
+	// the range of allowed conventions. Add new conventions before it.
+	outOfRangeConvention
 )
 
 // String returns the convention name.
 func (d Convention) String() string {
+	if d < ActualActual || d >= outOfRangeConvention {
+		return "Unsupported"
+	}
+
 	return [...]string{
 		"ActualActual",
 		"ActualActualAFB",
@@ -65,20 +72,28 @@ func Parse(convention string) (Convention, error) {
 	switch convention {
 	case "ActualActual":
 		return ActualActual, nil
+
 	case "ActualActualAFB":
 		return ActualActualAFB, nil
+
 	case "ActualThreeSixty":
 		return ActualThreeSixty, nil
+
 	case "ActualThreeSixtyFiveFixed":
 		return ActualThreeSixtyFiveFixed, nil
+
 	case "ThirtyThreeSixtyUS":
 		return ThirtyThreeSixtyUS, nil
+
 	case "ThirtyThreeSixtyEuropean":
 		return ThirtyThreeSixtyEuropean, nil
+
 	case "ThirtyThreeSixtyItalian":
 		return ThirtyThreeSixtyItalian, nil
+
 	case "ThirtyThreeSixtyGerman":
 		return ThirtyThreeSixtyGerman, nil
+
 	default:
 		return -1, fmt.Errorf("unrecognized daycount convention %s", convention)
 	}
@@ -102,7 +117,5 @@ func (d *Convention) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON implements the JSON marshaler.
 func (d Convention) MarshalJSON() ([]byte, error) {
-	return bytes.NewBufferString(
-		fmt.Sprintf(`"%s"`, d.String()),
-	).Bytes(), nil
+	return []byte(fmt.Sprintf(`"%s"`, d.String())), nil
 }

--- a/convention_test.go
+++ b/convention_test.go
@@ -46,6 +46,10 @@ func Test_Convention_String(t *testing.T) {
 			"ThirtyThreeSixtyGerman",
 			ThirtyThreeSixtyGerman,
 		},
+		{
+			"Unsupported",
+			Convention(666),
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/daycount.go
+++ b/daycount.go
@@ -36,7 +36,7 @@ func NewDayCounter(convention Convention) DayCounter {
 	case ThirtyThreeSixtyGerman:
 		return yearFractionThirtyThreeSixtyGerman
 
-	case ActualActual:
+	case ActualActual, outOfRangeConvention:
 		fallthrough
 
 	default:

--- a/daycount_test.go
+++ b/daycount_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const epsilon = 1.0e-6
+const epsilon = 1.0e-15
 
 func Test_YearFraction(t *testing.T) {
 	t.Parallel()
@@ -183,6 +183,21 @@ func Test_YearFraction(t *testing.T) {
 			})
 		}
 	}
+}
+
+func Test_YearFraction_outOfRangeConvention(t *testing.T) {
+	t.Parallel()
+
+	var (
+		from = date.Today()
+		to   = from.AddDate(1, 0, 0)
+	)
+
+	assert.InEpsilon(t,
+		YearFraction(from, to, ActualActual),
+		YearFraction(from, to, outOfRangeConvention),
+		epsilon,
+	)
 }
 
 func Test_YearFraction_EqualDates(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelaboratories/daycount
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9


### PR DESCRIPTION
Updating a bit the code:
- add `outOfRangeConvention` to check bounds in `String`: **this avoids panicking for unknown conventions**
- upgrading to **Go 1.20**
- removing unnecessary use of bytes buffer
- adding newlines in switch