### PR TITLE
fix: inverting year fraction should give opposite sign

### DIFF
--- a/daycount.go
+++ b/daycount.go
@@ -76,12 +76,12 @@ func yearFractionActualActualAFB(from, to date.Date) float64 {
 
 	// This function uses backward induction from the later date,
 	// 'from' and 'to' are swapped if 'to' falls before 'from'.
-	alpha := 1.0
+	sign := 1.0
 	if to.Before(from) {
-		alpha = -1.0
+		sign = -1.0
 
 		remaining = from
-		from, to = to, remaining
+		from, to = to, from
 	}
 
 	for tmp := to; tmp.After(from); {
@@ -98,7 +98,7 @@ func yearFractionActualActualAFB(from, to date.Date) float64 {
 		}
 	}
 
-	return alpha * (float64(nbFullYears) + float64(remaining.Sub(from))/computeYearDurationAFB(from, remaining))
+	return sign * (float64(nbFullYears) + float64(remaining.Sub(from))/computeYearDurationAFB(from, remaining))
 }
 
 func computeYearDurationAFB(from, remaining date.Date) float64 {

--- a/daycount.go
+++ b/daycount.go
@@ -73,6 +73,17 @@ func yearFractionActualActualAFB(from, to date.Date) float64 {
 	nbFullYears := 0
 
 	remaining := to
+
+	// This function uses backward induction from the later date,
+	// 'from' and 'to' are swapped if 'to' falls before 'from'.
+	alpha := 1.0
+	if to.Before(from) {
+		alpha = -1.0
+
+		remaining = from
+		from, to = to, remaining
+	}
+
 	for tmp := to; tmp.After(from); {
 		tmp = tmp.AddDate(-1, 0, 0)
 		year, month, day := tmp.Date()
@@ -87,7 +98,7 @@ func yearFractionActualActualAFB(from, to date.Date) float64 {
 		}
 	}
 
-	return float64(nbFullYears) + float64(remaining.Sub(from))/computeYearDurationAFB(from, remaining)
+	return alpha * (float64(nbFullYears) + float64(remaining.Sub(from))/computeYearDurationAFB(from, remaining))
 }
 
 func computeYearDurationAFB(from, remaining date.Date) float64 {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9
 	github.com/google/gofuzz v1.2.0
+	github.com/leanovate/gopter v0.2.9
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9 h1:NERIc41aohgojUAgWC
 github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9/go.mod h1:UoIEyXCyEJ1Zu3ejiUOSngl9U5Oe9S+qaNiYiUex2nk=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
+github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
## Context

While comparing `daycount` and `elgorian`, I noticed an inconsistency on `daycount` side concerning `ActualActualAFB` which produced a wrong value when `to` was before `from` and a 29th February was comprise within the interval `[to, from]`.

## Content

Since the year fraction computation is done on a backward induction, the function now inverts `from` and `to` if `to` is before `from`.

A property test is added to make sure that inverting `from` and `to` returns the opposite value (`* -1.0`).