### PR TITLE
deps: use edgelaboratories/date instead fxtlabs/date

### DIFF
--- a/daycount.go
+++ b/daycount.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 )
 
 // DayCounter computes the year fraction between a from and a to date

--- a/daycount_test.go
+++ b/daycount_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 	fuzz "github.com/google/gofuzz"
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelaboratories/daycount
 go 1.20
 
 require (
-	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9
+	github.com/edgelaboratories/date v1.0.0
 	github.com/google/gofuzz v1.2.0
 	github.com/leanovate/gopter v0.2.9
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9 h1:NERIc41aohgojUAgWCCnN5B8dIXZsBo2UC04LR3tbao=
-github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9/go.mod h1:UoIEyXCyEJ1Zu3ejiUOSngl9U5Oe9S+qaNiYiUex2nk=
+github.com/edgelaboratories/date v1.0.0 h1:7fLFULv4CN8p4y2tF4HL6pkiineu9pTB7tPY5JGmMU8=
+github.com/edgelaboratories/date v1.0.0/go.mod h1:Tp8irw0RW41T/Bnhe8q6AZjDyVuDcwPU3vl93t2GoOM=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=


### PR DESCRIPTION
## Context

In the road of unifying libraries of QE services, it seems suitable to get rid of the usage of `fxtlabs/date` to replace it with `edgelaboratories/date`. The latter is a fork of the inactive package `fxtlabs/date` with slight improvements. It still lets us the possibility to add further modifications to it.

## Content

Replace the use of  `fxtlabs/date` by `edgelaboratories/date`