### PR TITLE
code: go version to 1.21.6

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Update dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelaboratories/daycount
 
-go 1.20
+go 1.21.6
 
 require (
 	github.com/edgelaboratories/date v1.0.0


### PR DESCRIPTION
## Context

#62 is blocked due to testing being stuck on 1.20

## Content

This PR updates go version to 1.21.6 and the associated github workflow.
